### PR TITLE
feat: add total dose explanation to dcc cover page

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -114,4 +114,8 @@ export default {
     "cover.whichCode.title": "Which QR code should I use?",
     "cover.whichCode.text":
         "Which QR code you have to show depends on the demands of the country you're visiting.  Before leaving, please always check which certificate you need at your destination at [netherlandsworldwide.nl](https://netherlandsworldwide.nl).",
+    "cover.totalDoseExplanation.title":
+        "What does the number after my vaccination dose mean?",
+    "cover.totalDoseExplanation.text":
+        "The first number indicates the number of vaccinations you’ve had. The second number indicates how many vaccinations you need to be considered fully vaccinated. For more information please visit [coronacheck.nl/en/dose](https://coronacheck.nl/en/dose).",
 };

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -113,4 +113,9 @@ export default {
     "cover.whichCode.title": "Welke QR-code moet ik gebruiken?",
     "cover.whichCode.text":
         "Welke QR-code je moet laten zien hangt af van de eisen van het land dat je bezoekt. Controleer daarom altijd voor vertrek op [wijsopreis.nl](https://wijsopreis.nl) welk bewijs je nodig hebt.",
+
+    "cover.totalDoseExplanation.title":
+        "Wat betekent het nummer achter mijn vaccinatie-dosis?",
+    "cover.totalDoseExplanation.text":
+        "Het eerste getal staat voor het aantal prikken dat je hebt gehad. Het tweede getal staat voor het aantal prikken dat jij nodig hebt voor volledige vaccinatie. Kijk voor meer informatie op  [coronacheck.nl/dosis](https://coronacheck.nl/dosis).",
 };

--- a/src/pdf/dccCoverPage.js
+++ b/src/pdf/dccCoverPage.js
@@ -45,117 +45,159 @@ export function addDccCoverPage(doc, proofs, createdAt) {
         doc.pdf.outline.addItem(t(doc.locale, "cover.title"));
 
         doc.addStruct("Art", [
+            sectContents(doc, euProofs),
+            sectLogo(doc),
+            sectIssuedOn(doc, createdAt),
+        ]);
+    });
+}
+
+function sectContents(doc, euProofs) {
+    var showTotalDoseExplanation = euProofs.some(function (proof) {
+        return (
+            proof.eventType === "vaccination" &&
+            proof.doseNumber > proof.totalDoses
+        );
+    });
+    var contents = [
+        structFigure(
+            doc,
+            {
+                x: pageWidth / 2 - 6.5,
+                y: 0,
+                width: 13,
+                height: 39,
+                alt: t(doc.locale, "alt.logoRijksoverheid"),
+            },
+            function () {
+                drawImage(doc, {
+                    x: pageWidth / 2 - 6.5,
+                    y: 0,
+                    width: 13,
+                    image: logoRijksoverheidA4,
+                });
+            }
+        ),
+        structText(doc, "H1", {
+            text: t(doc.locale, "cover.title"),
+            font: "MontserratBold",
+            size: fontSizeH1,
+            color: titleColor,
+            position: [marginX, textStart],
+            width: textWidth,
+            lineGap: 2,
+        }),
+        structText(doc, "P", {
+            text: "\n" + t(doc.locale, "cover.intro"),
+            font: "ROSansRegular",
+            size: fontSizeStandard,
+            position: [marginX, null],
+            width: textWidth,
+            lineGap: 2,
+        }),
+        doc.pdf.struct("Sect", [
+            structText(doc, "H2", {
+                text: "\n" + t(doc.locale, "cover.yourProofs.title"),
+                font: "ROSansBold",
+                size: fontSizeStandard,
+                position: [marginX, null],
+                width: textWidth,
+                lineGap: 2,
+            }),
+            structList(doc, {
+                items: formatEuProofEvents(euProofs, doc.locale),
+                font: "ROSansRegular",
+                size: fontSizeStandard,
+                position: [marginX + 3, null],
+                label: "•",
+                indent: 6,
+                lineGap: 1,
+            }),
+        ]),
+    ];
+    if (showTotalDoseExplanation) {
+        contents.push(
             doc.pdf.struct("Sect", [
-                structFigure(
-                    doc,
-                    {
-                        x: pageWidth / 2 - 6.5,
-                        y: 0,
-                        width: 13,
-                        height: 39,
-                        alt: t(doc.locale, "alt.logoRijksoverheid"),
-                    },
-                    function () {
-                        drawImage(doc, {
-                            x: pageWidth / 2 - 6.5,
-                            y: 0,
-                            width: 13,
-                            image: logoRijksoverheidA4,
-                        });
-                    }
-                ),
-                structText(doc, "H1", {
-                    text: t(doc.locale, "cover.title"),
-                    font: "MontserratBold",
-                    size: fontSizeH1,
-                    color: titleColor,
-                    position: [marginX, textStart],
+                structText(doc, "H2", {
+                    text:
+                        "\n" +
+                        t(doc.locale, "cover.totalDoseExplanation.title"),
+                    font: "ROSansBold",
+                    size: fontSizeStandard,
+                    position: [marginX, null],
                     width: textWidth,
                     lineGap: 2,
                 }),
                 structText(doc, "P", {
-                    text: "\n" + t(doc.locale, "cover.intro"),
+                    text: t(doc.locale, "cover.totalDoseExplanation.text"),
                     font: "ROSansRegular",
                     size: fontSizeStandard,
                     position: [marginX, null],
                     width: textWidth,
                     lineGap: 2,
                 }),
-                doc.pdf.struct("Sect", [
-                    structText(doc, "H2", {
-                        text: "\n" + t(doc.locale, "cover.yourProofs.title"),
-                        font: "ROSansBold",
-                        size: fontSizeStandard,
-                        position: [marginX, null],
-                        width: textWidth,
-                        lineGap: 2,
-                    }),
-                    structList(doc, {
-                        items: formatEuProofEvents(euProofs, doc.locale),
-                        font: "ROSansRegular",
-                        size: fontSizeStandard,
-                        position: [marginX + 3, null],
-                        label: "•",
-                        indent: 6,
-                        lineGap: 1,
-                    }),
-                ]),
-                doc.pdf.struct("Sect", [
-                    structText(doc, "H2", {
-                        text: "\n" + t(doc.locale, "cover.whichCode.title"),
-                        font: "ROSansBold",
-                        size: fontSizeStandard,
-                        position: [marginX, null],
-                        width: textWidth,
-                        lineGap: 2,
-                    }),
-                    structText(doc, "P", {
-                        text: t(doc.locale, "cover.whichCode.text"),
-                        font: "ROSansRegular",
-                        size: fontSizeStandard,
-                        position: [marginX, null],
-                        width: textWidth,
-                        lineGap: 2,
-                    }),
-                ]),
-            ]),
-            structFigure(
-                doc,
-                {
-                    x: marginX,
-                    y: pageHeight - marginY - 9,
-                    width: 46,
-                    height: 9,
-                    alt: t(doc.locale, "alt.logoCoronacheck"),
-                },
-                function () {
-                    var x = marginX;
-                    var y = pageHeight - marginY - 9;
-                    drawLogoCoronaCheck(doc, x, y, 9);
-                    drawText(doc, {
-                        text: "CoronaCheck",
-                        font: "MontserratBold",
-                        size: 14,
-                        color: titleColor,
-                        position: [x + 12, y + 4.5],
-                        baseline: "middle",
-                    });
-                }
-            ),
+            ])
+        );
+    }
+    contents.push(
+        doc.pdf.struct("Sect", [
+            structText(doc, "H2", {
+                text: "\n" + t(doc.locale, "cover.whichCode.title"),
+                font: "ROSansBold",
+                size: fontSizeStandard,
+                position: [marginX, null],
+                width: textWidth,
+                lineGap: 2,
+            }),
             structText(doc, "P", {
-                text: t(doc.locale, "cover.issuedOn", {
-                    date: formatLocalDate(createdAt),
-                }),
+                text: t(doc.locale, "cover.whichCode.text"),
                 font: "ROSansRegular",
                 size: fontSizeStandard,
-                width: 50,
-                align: "right",
-                position: [
-                    pageWidth - marginX - 50,
-                    pageHeight - marginY - 4.5,
-                ],
-                baseline: "middle",
+                position: [marginX, null],
+                width: textWidth,
+                lineGap: 2,
             }),
-        ]);
+        ])
+    );
+    return doc.pdf.struct("Sect", contents);
+}
+
+function sectLogo(doc) {
+    return structFigure(
+        doc,
+        {
+            x: marginX,
+            y: pageHeight - marginY - 9,
+            width: 46,
+            height: 9,
+            alt: t(doc.locale, "alt.logoCoronacheck"),
+        },
+        function () {
+            var x = marginX;
+            var y = pageHeight - marginY - 9;
+            drawLogoCoronaCheck(doc, x, y, 9);
+            drawText(doc, {
+                text: "CoronaCheck",
+                font: "MontserratBold",
+                size: 14,
+                color: titleColor,
+                position: [x + 12, y + 4.5],
+                baseline: "middle",
+            });
+        }
+    );
+}
+
+function sectIssuedOn(doc, createdAt) {
+    return structText(doc, "P", {
+        text: t(doc.locale, "cover.issuedOn", {
+            date: formatLocalDate(createdAt),
+        }),
+        font: "ROSansRegular",
+        size: fontSizeStandard,
+        width: 50,
+        align: "right",
+        position: [pageWidth - marginX - 50, pageHeight - marginY - 4.5],
+        baseline: "middle",
     });
 }


### PR DESCRIPTION
Add explanation to DCC cover page when `doseNumber > totalDoses`.